### PR TITLE
Remove hardcoded SpotifyIcon tailwind class value

### DIFF
--- a/app/(nav)/(icons)/SpotifyIcon.jsx
+++ b/app/(nav)/(icons)/SpotifyIcon.jsx
@@ -1,7 +1,6 @@
 export default function SpotifyIcon({ ...rest }) {
   return (
     <svg
-      className="mx-1"
       fill="none"
       height={35}
       viewBox="0 0 35 36"

--- a/app/page.jsx
+++ b/app/page.jsx
@@ -15,7 +15,7 @@ export default function Home() {
   const loginButtonContent = () => {
     return (
       <span className="flex items-center">
-        Login With <SpotifyIcon /> Spotify
+        Login With <SpotifyIcon className="mx-1" /> Spotify
       </span>
     );
   };


### PR DESCRIPTION
Just passes className as a prop to SpotifyIcon rather than hardcoding it to every instance of the component.