### PR TITLE
LandingTransition component

### DIFF
--- a/app/LandingTransition.jsx
+++ b/app/LandingTransition.jsx
@@ -1,0 +1,11 @@
+import styles from '@/styles/Home.module.css';
+
+export default function LandingTransition({ children }) {
+  return (
+    <div className="h-screen flex flex-row justify-start">
+      <div className={`bg-main text-primary flex-1 ${styles.main}`}>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/app/page.jsx
+++ b/app/page.jsx
@@ -4,10 +4,11 @@ import { useSearchParams } from 'next/navigation';
 
 import useAuth from '@/hooks/useAuth';
 import Landing from './Landing';
+import LandingTransition from './LandingTransition';
 
 export default function Home() {
   const searchParams = useSearchParams();
   const accessToken = searchParams.get('access_token');
   useAuth(searchParams);
-  return <div>{accessToken ? <p>loading</p> : <Landing />}</div>;
+  return <div>{accessToken ? <LandingTransition /> : <Landing />}</div>;
 }


### PR DESCRIPTION
Create a LandingTransition component to render if landing page is visited with credentials as queries (meaning it's a redirection from spotify.com). Doing so prevent the landing page from being rendered again and smooth the transition to now-playing.